### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/modules/codegen.ts
+++ b/modules/codegen.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { defineNuxtModule } from '@nuxt/kit'
 import { generate } from '@graphql-codegen/cli'
@@ -44,6 +45,7 @@ export default defineNuxtModule<CodegenOptions>({
         await generateCode()
       })
       nuxt.hook('builder:watch', async (event, path) => {
+        path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
         const files = documents.map(doc => glob.sync(doc, {
           absolute: true,
         })).flat()


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

